### PR TITLE
Add more pages to code-only sample

### DIFF
--- a/samples/ControlCatalog.CodeOnly/App.cs
+++ b/samples/ControlCatalog.CodeOnly/App.cs
@@ -1,0 +1,27 @@
+using System;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class App : Application
+    {
+        public override void Initialize()
+        {
+            Styles.Add(new FluentTheme());
+        }
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.MainWindow = new MainWindow();
+            }
+
+            base.OnFrameworkInitializationCompleted();
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/BorderPage.cs
+++ b/samples/ControlCatalog.CodeOnly/BorderPage.cs
@@ -1,0 +1,103 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+using Avalonia.Media.Imaging;
+namespace ControlCatalog.CodeOnly
+
+{
+    public class BorderPage : UserControl
+    {
+        public BorderPage()
+        {
+            var accent = (Color)Application.Current!.Resources["SystemAccentColor"]!;
+            var accentDark1 = (Color)Application.Current!.Resources["SystemAccentColorDark1"]!;
+            var semiTransparentAccent = new SolidColorBrush(accent) { Opacity = 0.4 };
+
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Classes = { "h2" },
+                        Text = "A control which decorates a child with a border and background"
+                    },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Vertical,
+                        Margin = new Thickness(0,16,0,0),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 16,
+                        Children =
+                        {
+                            new Border
+                            {
+                                BorderBrush = new SolidColorBrush(accent),
+                                BorderThickness = new Thickness(2),
+                                Padding = new Thickness(16),
+                                Child = new TextBlock { Text = "Border" }
+                            },
+                            new Border
+                            {
+                                Background = new SolidColorBrush(accentDark1),
+                                BorderBrush = semiTransparentAccent,
+                                BackgroundSizing = BackgroundSizing.CenterBorder,
+                                BorderThickness = new Thickness(8),
+                                Padding = new Thickness(12),
+                                Child = new TextBlock { Text = "Background And CenterBorder" }
+                            },
+                            new Border
+                            {
+                                Background = new SolidColorBrush(accentDark1),
+                                BorderBrush = semiTransparentAccent,
+                                BackgroundSizing = BackgroundSizing.InnerBorderEdge,
+                                BorderThickness = new Thickness(8),
+                                Padding = new Thickness(12),
+                                Child = new TextBlock { Text = "Background And InnerBorder" }
+                            },
+                            new Border
+                            {
+                                Background = new SolidColorBrush(accentDark1),
+                                BorderBrush = semiTransparentAccent,
+                                BackgroundSizing = BackgroundSizing.OuterBorderEdge,
+                                BorderThickness = new Thickness(8),
+                                Padding = new Thickness(12),
+                                Child = new TextBlock { Text = "Background And OuterBorderEdge" }
+                            },
+                            new Border
+                            {
+                                BorderBrush = new SolidColorBrush(accent),
+                                BorderThickness = new Thickness(4),
+                                CornerRadius = new CornerRadius(8),
+                                Padding = new Thickness(16),
+                                Child = new TextBlock { Text = "Rounded Corners" }
+                            },
+                            new Border
+                            {
+                                Background = new SolidColorBrush(accent),
+                                CornerRadius = new CornerRadius(8),
+                                Padding = new Thickness(16),
+                                Child = new TextBlock { Text = "Rounded Corners" }
+                            },
+                            new Border
+                            {
+                                Width = 100,
+                                Height = 100,
+                                BorderThickness = new Thickness(0),
+                                Background = Brushes.White,
+                                CornerRadius = new CornerRadius(100),
+                                ClipToBounds = true,
+                                Child = new Image { Source = new Bitmap("/Assets/maple-leaf-888807_640.jpg"), Stretch = Stretch.UniformToFill }
+                            },
+                            new TextBlock { Text = "Border with Clipping", HorizontalAlignment = HorizontalAlignment.Center }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/ButtonsPage.cs
+++ b/samples/ControlCatalog.CodeOnly/ButtonsPage.cs
@@ -1,0 +1,175 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Data;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class ButtonsPage : UserControl
+    {
+        private int _repeatClicks;
+
+        public ButtonsPage()
+        {
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Width = 450,
+                Children =
+                {
+                    CreateHeader("Button", "A standard button control"),
+                    CreateButtonSection(),
+                    CreateHeader("ToggleButton", "A button control with multiple states: checked, unchecked or indeterminate."),
+                    new Border
+                    {
+                        Classes = { "thin" },
+                        Padding = new Thickness(15),
+                        Child = new StackPanel
+                        {
+                            Orientation = Orientation.Vertical,
+                            Spacing = 8,
+                            Children = { new ToggleButton { Content = "Toggle Button" } }
+                        }
+                    },
+                    CreateHeader("RepeatButton", "A button control that raises its Click event repeatedly when it is pressed and held."),
+                    CreateRepeatSection(),
+                    CreateHeader("HyperlinkButton", "A button control that functions as a navigable hyperlink."),
+                    CreateHyperlinkSection()
+                }
+            };
+        }
+
+        private Border CreateHeader(string text, string description)
+        {
+            return new Border
+            {
+                Classes = { "header-border" },
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Vertical,
+                    Spacing = 4,
+                    Children =
+                    {
+                        new TextBlock { Text = text, Classes = { "header" } },
+                        new TextBlock { Text = description, TextWrapping = TextWrapping.Wrap }
+                    }
+                }
+            };
+        }
+
+        private Border CreateButtonSection()
+        {
+            var column1 = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 8,
+                Width = 200,
+                Children =
+                {
+                    new Button { Content = "Standard _XAML Button" },
+                    new Button { Content = "Foreground", Foreground = Brushes.White },
+                    new Button { Content = "Background", Background = new SolidColorBrush((Color)Application.Current!.Resources["SystemAccentColor"]!) },
+                    new Button { Content = "Disabled", IsEnabled = false },
+                    new Button { Content = "Accent", Classes = { "accent" } }
+                }
+            };
+
+            var column2 = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 8,
+                Width = 200,
+                Children =
+                {
+                    new Button { Content = "No Border", BorderThickness = new Thickness(0) },
+                    new Button { Content = "Border Color", BorderBrush = new SolidColorBrush((Color)Application.Current!.Resources["SystemAccentColor"]!) },
+                    new Button { Content = "Thick Border", BorderBrush = new SolidColorBrush((Color)Application.Current!.Resources["SystemAccentColor"]!), BorderThickness = new Thickness(4) },
+                    new Button { Content = "Disabled", BorderBrush = new SolidColorBrush((Color)Application.Current!.Resources["SystemAccentColor"]!), BorderThickness = new Thickness(4), IsEnabled = false },
+                    new Button { Content = "IsTabStop=False", BorderBrush = new SolidColorBrush((Color)Application.Current!.Resources["SystemAccentColor"]!), IsTabStop = false }
+                }
+            };
+
+            return new Border
+            {
+                Classes = { "thin" },
+                Padding = new Thickness(15),
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Spacing = 10,
+                    Children = { column1, column2 }
+                }
+            };
+        }
+
+        private Border CreateRepeatSection()
+        {
+            var text = new TextBlock { Name = "RepeatButtonTextBlock", Text = "Repeat Button: 0" };
+            var button = new RepeatButton { Name = "RepeatButton", Content = text };
+            button.Click += (_, _) => text.Text = $"Repeat Button: {++_repeatClicks}";
+
+            return new Border
+            {
+                Classes = { "thin" },
+                Padding = new Thickness(15),
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Vertical,
+                    Spacing = 8,
+                    Children = { button }
+                }
+            };
+        }
+
+        private Border CreateHyperlinkSection()
+        {
+            var hyperlink = new HyperlinkButton
+            {
+                Name = "EnabledHyperlinkButton",
+                NavigateUri = new System.Uri("https://docs.avaloniaui.net/docs/welcome"),
+                VerticalAlignment = VerticalAlignment.Center,
+                Content = new TextBlock { Text = "Avalonia Docs" }
+            };
+
+            var checkBox = new CheckBox
+            {
+                Content = "IsVisited",
+                Margin = new Thickness(10,0,0,0),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            checkBox.Bind(ToggleButton.IsCheckedProperty, new Binding
+            {
+                Path = "IsVisited",
+                Source = hyperlink
+            });
+
+            return new Border
+            {
+                Classes = { "thin" },
+                Padding = new Thickness(15),
+                Child = new StackPanel
+                {
+                    Orientation = Orientation.Vertical,
+                    Spacing = 8,
+                    Children =
+                    {
+                        new StackPanel
+                        {
+                            Orientation = Orientation.Horizontal,
+                            Children = { hyperlink, checkBox }
+                        },
+                        new HyperlinkButton
+                        {
+                            IsEnabled = false,
+                            NavigateUri = new System.Uri("https://docs.avaloniaui.net/docs/welcome"),
+                            Content = new TextBlock { Text = "Avalonia Docs" }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/CanvasPage.cs
+++ b/samples/ControlCatalog.CodeOnly/CanvasPage.cs
@@ -1,0 +1,125 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Avalonia.Layout;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class CanvasPage : UserControl
+    {
+        public CanvasPage()
+        {
+            var canvas = new Canvas
+            {
+                Background = Brushes.Yellow,
+                Width = 300,
+                Height = 400
+            };
+
+            canvas.Children.Add(new Rectangle
+            {
+                Fill = Brushes.Blue,
+                Width = 63,
+                Height = 41,
+                RadiusX = 10,
+                RadiusY = 10,
+                [Canvas.LeftProperty] = 40,
+                [Canvas.TopProperty] = 31,
+                OpacityMask = new LinearGradientBrush
+                {
+                    StartPoint = new RelativePoint(0,0,RelativeUnit.Relative),
+                    EndPoint = new RelativePoint(1,1,RelativeUnit.Relative),
+                    GradientStops = new GradientStops
+                    {
+                        new GradientStop(Colors.Black,0),
+                        new GradientStop(Colors.Transparent,1)
+                    }
+                }
+            });
+
+            canvas.Children.Add(new Rectangle
+            {
+                Fill = new SolidColorBrush(Color.Parse("hsva(240,83%,73%,90%)")),
+                Stroke = new SolidColorBrush(Color.Parse("hsl(5,85%,85%)")),
+                StrokeThickness = 2,
+                Width = 40,
+                Height = 20,
+                RadiusX = 10,
+                RadiusY = 5,
+                [Canvas.LeftProperty] = 150,
+                [Canvas.TopProperty] = 10
+            });
+
+            canvas.Children.Add(new Ellipse
+            {
+                Fill = Brushes.Green,
+                Width = 58,
+                Height = 58,
+                [Canvas.LeftProperty] = 88,
+                [Canvas.TopProperty] = 100
+            });
+
+            canvas.Children.Add(new Path
+            {
+                Fill = Brushes.Orange,
+                Data = Geometry.Parse("M 0,0 c 0,0 50,0 50,-50 c 0,0 50,0 50,50 h -50 v 50 l -50,-50 Z"),
+                [Canvas.LeftProperty] = 30,
+                [Canvas.TopProperty] = 250
+            });
+
+            var geometry = new PathGeometry();
+            var figure = new PathFigure { StartPoint = new Point(0,0), IsClosed = true };
+            figure.Segments.Add(new QuadraticBezierSegment { Point1 = new Point(50,0), Point2 = new Point(50,-50) });
+            figure.Segments.Add(new QuadraticBezierSegment { Point1 = new Point(100,-50), Point2 = new Point(100,0) });
+            figure.Segments.Add(new LineSegment { Point = new Point(50,0) });
+            figure.Segments.Add(new LineSegment { Point = new Point(50,50) });
+            geometry.Figures.Add(figure);
+
+            canvas.Children.Add(new Path
+            {
+                Fill = Brushes.OrangeRed,
+                Data = geometry,
+                [Canvas.LeftProperty] = 180,
+                [Canvas.TopProperty] = 250
+            });
+
+            canvas.Children.Add(new Line
+            {
+                StartPoint = new Point(120,185),
+                EndPoint = new Point(30,115),
+                Stroke = Brushes.Red,
+                StrokeThickness = 2
+            });
+
+            canvas.Children.Add(new Polygon
+            {
+                Points = new Points { new Point(75,0), new Point(120,120), new Point(0,45), new Point(150,45), new Point(30,120) },
+                Stroke = Brushes.DarkBlue,
+                StrokeThickness = 1,
+                Fill = Brushes.Violet,
+                [Canvas.LeftProperty] = 150,
+                [Canvas.TopProperty] = 31
+            });
+
+            canvas.Children.Add(new Polyline
+            {
+                Points = new Points { new Point(0,0), new Point(65,0), new Point(78,-26), new Point(91,39), new Point(104,-39), new Point(117,13), new Point(130,0), new Point(195,0) },
+                Stroke = Brushes.Brown,
+                [Canvas.LeftProperty] = 30,
+                [Canvas.TopProperty] = 350
+            });
+
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock { Classes = { "h2" }, Text = "A panel which lays out its children by explicit coordinates" },
+                    canvas
+                }
+            };
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/CheckBoxPage.cs
+++ b/samples/ControlCatalog.CodeOnly/CheckBoxPage.cs
@@ -1,0 +1,57 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class CheckBoxPage : UserControl
+    {
+        public CheckBoxPage()
+        {
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock { Classes = { "h2" }, Text = "A check box control" },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Margin = new Thickness(0,16,0,0),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 16,
+                        Children =
+                        {
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new CheckBox { Content = "_Unchecked" },
+                                    new CheckBox { Content = "_Checked", IsChecked = true },
+                                    new CheckBox { Content = "_Indeterminate", IsChecked = null },
+                                    new CheckBox { Content = "Disabled", IsChecked = true, IsEnabled = false },
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                HorizontalAlignment = HorizontalAlignment.Center,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new CheckBox { Content = "Three State: Unchecked", IsThreeState = true, IsChecked = false },
+                                    new CheckBox { Content = "Three State: Checked", IsThreeState = true, IsChecked = true },
+                                    new CheckBox { Content = "Three State: Indeterminate", IsThreeState = true, IsChecked = null },
+                                    new CheckBox { Content = "Three State: Disabled", IsThreeState = true, IsChecked = null, IsEnabled = false },
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/ControlCatalog.CodeOnly.csproj
+++ b/samples/ControlCatalog.CodeOnly/ControlCatalog.CodeOnly.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.Desktop\Avalonia.Desktop.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AvaloniaResource Include="..\ControlCatalog\Assets\**\*">
+      <Link>Assets\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </AvaloniaResource>
+  </ItemGroup>
+  <Import Project="..\..\build\SampleApp.props" />
+</Project>

--- a/samples/ControlCatalog.CodeOnly/ExpanderPage.cs
+++ b/samples/ControlCatalog.CodeOnly/ExpanderPage.cs
@@ -1,0 +1,111 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Data;
+using Avalonia.Controls.Primitives;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class ExpanderPage : UserControl
+    {
+        private class ExpanderPageViewModel : INotifyPropertyChanged
+        {
+            private bool _rounded;
+            private CornerRadius? _cornerRadius;
+
+            public event PropertyChangedEventHandler? PropertyChanged;
+
+            public bool Rounded
+            {
+                get => _rounded;
+                set
+                {
+                    if (_rounded != value)
+                    {
+                        _rounded = value;
+                        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Rounded)));
+                        CornerRadius = _rounded ? new CornerRadius(25) : (CornerRadius?)null;
+                    }
+                }
+            }
+
+            public CornerRadius? CornerRadius
+            {
+                get => _cornerRadius;
+                private set
+                {
+                    if (_cornerRadius != value)
+                    {
+                        _cornerRadius = value;
+                        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CornerRadius)));
+                    }
+                }
+            }
+        }
+
+        public ExpanderPage()
+        {
+            var vm = new ExpanderPageViewModel();
+            DataContext = vm;
+
+            var expanderUp = CreateExpander("Expand Up", ExpandDirection.Up);
+            var expanderDown = CreateExpander("Expand Down", ExpandDirection.Down);
+            var expanderLeft = CreateExpander("Expand Left", ExpandDirection.Left);
+            var expanderRight = CreateExpander("Expand Right", ExpandDirection.Right);
+            var headerControl = new Button { Content = "Control in Header" };
+            var expanderHeaderControl = CreateExpander(headerControl, ExpandDirection.Down);
+            var disabled = CreateExpander("Disabled", ExpandDirection.Down);
+            disabled.IsEnabled = false;
+
+            var collapsingDisabled = CreateExpander("Collapsing Disabled", ExpandDirection.Down);
+            collapsingDisabled.IsExpanded = true;
+            collapsingDisabled.Collapsing += (_, e) => e.Cancel = true;
+
+            var expandingDisabled = CreateExpander("Expanding Disabled", ExpandDirection.Down);
+            expandingDisabled.Expanding += (_, e) => e.Cancel = true;
+
+            var rounded = new CheckBox { Content = "Rounded" };
+            rounded.Bind(ToggleButton.IsCheckedProperty, new Binding("Rounded") { Mode = BindingMode.TwoWay });
+
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock { Classes = { "h2" }, Text = "Expands to show nested content" },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Vertical,
+                        Margin = new Thickness(0,16,0,0),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 16,
+                        Children =
+                        {
+                            expanderUp,
+                            expanderDown,
+                            expanderLeft,
+                            expanderRight,
+                            expanderHeaderControl,
+                            disabled,
+                            rounded,
+                            collapsingDisabled,
+                            expandingDisabled
+                        }
+                    }
+                }
+            };
+
+            Content = panel;
+        }
+
+        private Expander CreateExpander(object header, ExpandDirection dir)
+        {
+            var expander = new Expander { Header = header, ExpandDirection = dir };
+            expander.Content = new StackPanel { Children = { new TextBlock { Text = "Expanded content" } } };
+            expander.Bind(Expander.CornerRadiusProperty, new Binding("CornerRadius"));
+            return expander;
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/MainWindow.cs
+++ b/samples/ControlCatalog.CodeOnly/MainWindow.cs
@@ -1,0 +1,41 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Controls.Primitives;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            Title = "ControlCatalog CodeOnly";
+            Width = 800;
+            Height = 600;
+
+            Content = CreateContent();
+        }
+
+        private Control CreateContent()
+        {
+            var tabs = new TabControl
+            {
+                Items =
+                {
+                    new TabItem { Header = "CheckBox", Content = new CheckBoxPage() },
+                    new TabItem { Header = "Buttons", Content = new ButtonsPage() },
+                    new TabItem { Header = "Slider", Content = new SliderPage() },
+                    new TabItem { Header = "Border", Content = new BorderPage() },
+                    new TabItem { Header = "ProgressBar", Content = new ProgressBarPage() },
+                    new TabItem { Header = "RadioButton", Content = new RadioButtonPage() },
+                    new TabItem { Header = "ToggleSwitch", Content = new ToggleSwitchPage() },
+                    new TabItem { Header = "Canvas", Content = new CanvasPage() },
+                    new TabItem { Header = "Expander", Content = new ExpanderPage() },
+                    new TabItem { Header = "Viewbox", Content = new ViewboxPage() }
+                }
+            };
+
+            return tabs;
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/Program.cs
+++ b/samples/ControlCatalog.CodeOnly/Program.cs
@@ -1,0 +1,17 @@
+using System;
+using Avalonia;
+
+namespace ControlCatalog.CodeOnly
+{
+    class Program
+    {
+        [STAThread]
+        public static int Main(string[] args)
+            => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+        public static AppBuilder BuildAvaloniaApp()
+            => AppBuilder.Configure<App>()
+                .UsePlatformDetect()
+                .LogToTrace();
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/ProgressBarPage.cs
+++ b/samples/ControlCatalog.CodeOnly/ProgressBarPage.cs
@@ -1,0 +1,122 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class ProgressBarPage : UserControl
+    {
+        public ProgressBarPage()
+        {
+            var maximum = new NumericUpDown { Value = 100, VerticalAlignment = VerticalAlignment.Center };
+            var minimum = new NumericUpDown { Value = 0, VerticalAlignment = VerticalAlignment.Center };
+            var stringFormat = new TextBox { Text = "{0:0}%", VerticalAlignment = VerticalAlignment.Center };
+            var showProgress = new CheckBox { Margin = new Thickness(10,16,0,0), Content = "Show Progress Text" };
+            var isIndeterminate = new CheckBox { Margin = new Thickness(10,16,0,0), Content = "Toggle Indeterminate" };
+            var hprogress = new Slider { Minimum = 0, Maximum = 100, Value = 40 };
+            var vprogress = new Slider { Minimum = 0, Maximum = 100, Value = 60 };
+
+            var horizontal = new ProgressBar();
+            var vertical = new ProgressBar { Orientation = Orientation.Vertical };
+
+            BindProgress(horizontal, hprogress, minimum, maximum, stringFormat, showProgress, isIndeterminate);
+            BindProgress(vertical, vprogress, minimum, maximum, stringFormat, showProgress, isIndeterminate);
+
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock { Classes = { "h2" }, Text = "A progress bar control" },
+                    new StackPanel
+                    {
+                        Spacing = 5,
+                        Children =
+                        {
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                Spacing = 5,
+                                Children =
+                                {
+                                    new TextBlock { Text = "Maximum", VerticalAlignment = VerticalAlignment.Center },
+                                    maximum
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                Spacing = 5,
+                                Children =
+                                {
+                                    new TextBlock { Text = "Minimum", VerticalAlignment = VerticalAlignment.Center },
+                                    minimum
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                Spacing = 5,
+                                Children =
+                                {
+                                    new TextBlock { Text = "Progress Text Format", VerticalAlignment = VerticalAlignment.Center },
+                                    stringFormat
+                                }
+                            },
+                            showProgress,
+                            isIndeterminate,
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                Margin = new Thickness(0,16,0,0),
+                                HorizontalAlignment = HorizontalAlignment.Center,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new StackPanel
+                                    {
+                                        Spacing = 16,
+                                        Children = { horizontal }
+                                    },
+                                    vertical
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Margin = new Thickness(16),
+                                Children =
+                                {
+                                    hprogress,
+                                    vprogress
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Spacing = 10,
+                                Children =
+                                {
+                                    new ProgressBar { Value = 5, Maximum = 10, VerticalAlignment = VerticalAlignment.Center },
+                                    new ProgressBar { Value = 50, VerticalAlignment = VerticalAlignment.Center },
+                                    new ProgressBar { Value = 50, Minimum = 25, Maximum = 75, VerticalAlignment = VerticalAlignment.Center }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        private static void BindProgress(ProgressBar bar, RangeBase slider, NumericUpDown min, NumericUpDown max, TextBox format, CheckBox show, CheckBox indeterminate)
+        {
+            bar.Bind(RangeBase.ValueProperty, new Binding { Source = slider, Path = nameof(Slider.Value) });
+            bar.Bind(RangeBase.MinimumProperty, new Binding { Source = min, Path = nameof(NumericUpDown.Value) });
+            bar.Bind(RangeBase.MaximumProperty, new Binding { Source = max, Path = nameof(NumericUpDown.Value) });
+            bar.Bind(ProgressBar.ProgressTextFormatProperty, new Binding { Source = format, Path = nameof(TextBox.Text) });
+            bar.Bind(ProgressBar.ShowProgressTextProperty, new Binding { Source = show, Path = nameof(ToggleButton.IsChecked) });
+            bar.Bind(ProgressBar.IsIndeterminateProperty, new Binding { Source = indeterminate, Path = nameof(ToggleButton.IsChecked) });
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/RadioButtonPage.cs
+++ b/samples/ControlCatalog.CodeOnly/RadioButtonPage.cs
@@ -1,0 +1,79 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+
+using Avalonia;
+namespace ControlCatalog.CodeOnly
+{
+    public class RadioButtonPage : UserControl
+    {
+        public RadioButtonPage()
+        {
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock { Classes = { "h2" }, Text = "Allows the selection of a single option of many" },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Margin = new Thickness(0,16,0,0),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 16,
+                        Children =
+                        {
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new RadioButton { Content = "_Option 1", IsChecked = true },
+                                    new RadioButton { Content = "O_ption 2" },
+                                    new RadioButton { Content = "Op_tion 3", IsChecked = null },
+                                    new RadioButton { Content = "Disabled", IsEnabled = false }
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new RadioButton { Content = "Three States: Option 1", IsThreeState = true, IsChecked = true },
+                                    new RadioButton { Content = "Three States: Option 2", IsThreeState = true, IsChecked = false },
+                                    new RadioButton { Content = "Three States: Option 3", IsThreeState = true, IsChecked = null },
+                                    new RadioButton { Content = "Disabled", IsThreeState = true, IsChecked = null, IsEnabled = false }
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new RadioButton { GroupName = "A", Content = "Group A: Option 1", IsChecked = true },
+                                    new RadioButton { GroupName = "A", Content = "Group A: Disabled", IsEnabled = false },
+                                    new RadioButton { GroupName = "B", Content = "Group B: Option 1" },
+                                    new RadioButton { GroupName = "B", Content = "Group B: Option 3", IsChecked = null }
+                                }
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                Spacing = 16,
+                                Children =
+                                {
+                                    new RadioButton { GroupName = "A", Content = "Group A: Option 2", IsChecked = true },
+                                    new RadioButton { GroupName = "B", Content = "Group B: Option 2" },
+                                    new RadioButton { GroupName = "B", Content = "Group B: Option 4", IsChecked = null }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/SliderPage.cs
+++ b/samples/ControlCatalog.CodeOnly/SliderPage.cs
@@ -1,0 +1,102 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Data;
+using Avalonia.Collections;
+using Avalonia.Controls.Primitives;
+using Avalonia.Styling;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class SliderPage : UserControl
+    {
+        public SliderPage()
+        {
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock { Classes = { "h2" }, Text = "A control that lets the user select from a range of values by moving a Thumb control along a Track." },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Margin = new Thickness(0,16,0,0),
+                        Spacing = 16,
+                        Children =
+                        {
+                            CreateVerticalStack(),
+                            CreateVerticalSlider(),
+                            CreateVerticalSlider(isReversed: true)
+                        }
+                    }
+                }
+            };
+        }
+
+        private Control CreateVerticalStack()
+        {
+            return new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Children =
+                {
+                    new Slider { Minimum = 0, Maximum = 100, TickFrequency = 10, Width = 300 },
+                    new Slider { Minimum = 0, Maximum = 100, TickPlacement = TickPlacement.BottomRight, IsSnapToTickEnabled = true, Ticks = new AvaloniaList<double> {0,20,25,40,75,100}, Width = 300 },
+                    new Slider { Minimum = 0, Maximum = 100, TickPlacement = TickPlacement.BottomRight, IsSnapToTickEnabled = true, IsDirectionReversed = true, Ticks = new AvaloniaList<double> {0,20,25,40,75,100}, Width = 300 },
+                    CreateTooltipSlider(),
+                    CreateValidationSlider(),
+                    new Slider { Minimum = 0, Maximum = 100, TickFrequency = 10, IsDirectionReversed = true, Width = 300 }
+                }
+            };
+        }
+
+        private Control CreateVerticalSlider(bool isReversed = false)
+        {
+            return new Slider
+            {
+                Minimum = 0,
+                Maximum = 100,
+                Orientation = Orientation.Vertical,
+                IsSnapToTickEnabled = true,
+                TickPlacement = TickPlacement.Outside,
+                TickFrequency = 10,
+                IsDirectionReversed = isReversed,
+                Height = 300
+            };
+        }
+
+        private Slider CreateValidationSlider()
+        {
+            var slider = new Slider { Minimum = 0, Maximum = 100, TickFrequency = 10, Width = 300 };
+            DataValidationErrors.SetError(slider, new System.Exception());
+            return slider;
+        }
+
+        private Slider CreateTooltipSlider()
+        {
+            var slider = new Slider
+            {
+                Minimum = 0,
+                Maximum = 100,
+                Width = 300
+            };
+
+            slider.Styles.Add(new Style(x => x.OfType<Thumb>())
+            {
+                Setters =
+                {
+                    new Setter(ToolTip.TipProperty, new Binding { Path = "$parent[Slider].Value", StringFormat = "Value {0:f}" }),
+                    new Setter(ToolTip.PlacementProperty, PlacementMode.Top),
+                    new Setter(ToolTip.VerticalOffsetProperty, -10.0),
+                    new Setter(ToolTip.HorizontalOffsetProperty, -30.0)
+                }
+            });
+
+            return slider;
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/ToggleSwitchPage.cs
+++ b/samples/ControlCatalog.CodeOnly/ToggleSwitchPage.cs
@@ -1,0 +1,122 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media.Imaging;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class ToggleSwitchPage : UserControl
+    {
+        public ToggleSwitchPage()
+        {
+            Styles.Add(new Style(x => x.OfType<TextBox>().Class("CodeBox"))
+            {
+                Setters =
+                {
+                    new Setter(TextBox.PaddingProperty, new Thickness(10)),
+                    new Setter(TextBox.IsReadOnlyProperty, true),
+                    new Setter(TextBox.BorderBrushProperty, Brushes.Transparent),
+                    new Setter(TextBox.FontSizeProperty, 14.0),
+                    new Setter(TextBox.IsEnabledProperty, true)
+                }
+            });
+
+            Styles.Add(new Style(x => x.OfType<TextBlock>().Class("header"))
+            {
+                Setters =
+                {
+                    new Setter(TextBlock.FontSizeProperty, 18.0),
+                    new Setter(TextBlock.MarginProperty, new Thickness(0,20,0,20))
+                }
+            });
+
+            Styles.Add(new Style(x => x.OfType<Border>().Class("Thin"))
+            {
+                Setters =
+                {
+                    new Setter(Border.BorderBrushProperty, Brushes.Gray),
+                    new Setter(Border.BorderThicknessProperty, new Thickness(0.5)),
+                    new Setter(Border.CornerRadiusProperty, new CornerRadius(2))
+                }
+            });
+
+            Content = new StackPanel
+            {
+                MaxWidth = 500,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Children =
+                {
+                    new TextBlock { Text = "Simple ToggleSwitch", Classes = { "header" } },
+                    new Border
+                    {
+                        Classes = { "Thin" },
+                        Child = new StackPanel
+                        {
+                            Children =
+                            {
+                                new ToggleSwitch { Margin = new Thickness(10) },
+                                new TextBox { Text = "<ToggleSwitch/>", Classes = { "CodeBox" } }
+                            }
+                        }
+                    },
+                    new TextBlock { Text = "Headered ToggleSwitch", Classes = { "header" } },
+                    new Border
+                    {
+                        Classes = { "Thin" },
+                        Child = new StackPanel
+                        {
+                            Children =
+                            {
+                                new ToggleSwitch { Content = "h_eadered", IsChecked = true, Margin = new Thickness(10) },
+                                new TextBox { Text = "<ToggleSwitch>headered</ToggleSwitch>", Classes = { "CodeBox" } }
+                            }
+                        }
+                    },
+                    new TextBlock { Text = "Custom content ToggleSwitch", Classes = { "header" } },
+                    new Border
+                    {
+                        Classes = { "Thin" },
+                        Child = new StackPanel
+                        {
+                            Children =
+                            {
+                                new ToggleSwitch
+                                {
+                                    Content = "_Custom",
+                                    OnContent = "On",
+                                    OffContent = "Off",
+                                    Margin = new Thickness(10)
+                                },
+                                new TextBox
+                                {
+                                    Text = "<ToggleSwitch Content=\"Custom\" ContentOn=\"On\" ContentOff=\"Off\" />",
+                                    Classes = { "CodeBox" }
+                                }
+                            }
+                        }
+                    },
+                    new TextBlock { Text = "Image content ToggleSwitch", Classes = { "header" } },
+                    new Border
+                    {
+                        Classes = { "Thin" },
+                        Child = new StackPanel
+                        {
+                            Children =
+                            {
+                                new ToggleSwitch
+                                {
+                                    Content = "_Just Click!",
+                                    Margin = new Thickness(10),
+                                    OnContent = new Image { Source = new Bitmap("/Assets/hirsch-899118_640.jpg"), Height = 32 },
+                                    OffContent = new Image { Source = new Bitmap("/Assets/delicate-arch-896885_640.jpg"), Height = 32 }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/samples/ControlCatalog.CodeOnly/ViewboxPage.cs
+++ b/samples/ControlCatalog.CodeOnly/ViewboxPage.cs
@@ -1,0 +1,101 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Controls.Shapes;
+
+namespace ControlCatalog.CodeOnly
+{
+    public class ViewboxPage : UserControl
+    {
+        public ViewboxPage()
+        {
+            var width = new Slider { Minimum = 10, Maximum = 200, Value = 100, TickFrequency = 25, TickPlacement = TickPlacement.TopLeft };
+            var height = new Slider { Minimum = 10, Maximum = 200, Value = 100, TickFrequency = 25, TickPlacement = TickPlacement.TopLeft };
+
+            var stretchSelector = new ComboBox
+            {
+                Items = { Stretch.Uniform, Stretch.UniformToFill, Stretch.Fill, Stretch.None },
+                SelectedIndex = 0,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Margin = new Thickness(0,0,0,2)
+            };
+
+            var stretchDirSelector = new ComboBox
+            {
+                Items = { StretchDirection.Both, StretchDirection.DownOnly, StretchDirection.UpOnly },
+                SelectedIndex = 0,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+
+            var viewbox = new Viewbox();
+            viewbox.Bind(Viewbox.StretchProperty, new Avalonia.Data.Binding { Source = stretchSelector, Path = nameof(ComboBox.SelectedItem) });
+            viewbox.Bind(Viewbox.StretchDirectionProperty, new Avalonia.Data.Binding { Source = stretchDirSelector, Path = nameof(ComboBox.SelectedItem) });
+            viewbox.Child = new Ellipse { Width = 50, Height = 50, Fill = Brushes.CornflowerBlue };
+
+            var innerBorder = new Border
+            {
+                BorderBrush = Brushes.CornflowerBlue,
+                BorderThickness = new Thickness(1)
+            };
+            innerBorder.Bind(WidthProperty, new Avalonia.Data.Binding { Source = width, Path = nameof(Slider.Value) });
+            innerBorder.Bind(HeightProperty, new Avalonia.Data.Binding { Source = height, Path = nameof(Slider.Value) });
+            innerBorder.Child = viewbox;
+
+            var outerBorder = new Border
+            {
+                BorderBrush = Brushes.Orange,
+                BorderThickness = new Thickness(1),
+                Width = 200,
+                Height = 200,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = innerBorder
+            };
+
+            Content = new Grid
+            {
+                RowDefinitions = new RowDefinitions("Auto,*,*"),
+                Children =
+                {
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Vertical,
+                        Spacing = 4,
+                        Children = { new TextBlock { Classes = { "h2" }, Text = "A control used to scale single child." } }
+                    },
+                    new Grid
+                    {
+                        ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+                        [Grid.RowProperty] = 1,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Margin = new Thickness(0,10,0,0),
+                        Children =
+                        {
+                            outerBorder,
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Vertical,
+                                HorizontalAlignment = HorizontalAlignment.Left,
+                                Margin = new Thickness(8,0,0,0),
+                                Width = 150,
+                                [Grid.ColumnProperty] = 1,
+                                Children =
+                                {
+                                    new TextBlock { Text = "Width" },
+                                    width,
+                                    new TextBlock { Text = "Height" },
+                                    height,
+                                    new TextBlock { Text = "Stretch" },
+                                    stretchSelector,
+                                    new TextBlock { Text = "Stretch Direction" },
+                                    stretchDirSelector
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port Canvas, Expander and Viewbox pages using code-only Avalonia
- wire the pages in the sample window

## Testing
- `dotnet build samples/ControlCatalog.CodeOnly/ControlCatalog.CodeOnly.csproj -c Release`
- `dotnet test tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687ca93634308321b2b47cc9ed7f9de9